### PR TITLE
fix: use ascii quotes in the charset meta tags

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<meta charset=“utf-8”>
+<meta charset="utf-8">
 <title>Reactions page</title>
 <div id="container"></div>
 <script src="http://localhost:8082/src/index.bundle"></script>

--- a/prod.html
+++ b/prod.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<meta charset=“utf-8”>
+<meta charset="utf-8">
 <title>Reactions page</title>
 <div id="container"></div>
 <script src="build/bundle.js"></script>


### PR DESCRIPTION
Pretty ironic that exactly the quotes for the charset make the charset not work 🤔 
