### PR TITLE
Basic version of an error overlay.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-preset-react": "^6.24.1",
     "metro": "^0.24.7",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "react-error-overlay": "^4.0.0"
   }
 }

--- a/src/hmr.js
+++ b/src/hmr.js
@@ -1,9 +1,51 @@
 'use strict';
 
-const HmrClient = require('metro/src/lib/bundle-modules/HmrClient.js');
+var ErrorOverlay = require('react-error-overlay');
+var HmrClient = require('metro/src/lib/bundle-modules/HmrClient.js');
 
-const hmrInstance = new HmrClient(
-  // TODO: make the URL/Entrypoint configurable
-  `ws://localhost:8082/hot?bundleEntry=src/index.js`,
-);
-hmrInstance.enable();
+var lastError = null;
+var setupDone = false;
+
+function clearOutdatedErrors() {
+  if (typeof console !== 'undefined' && typeof console.clear === 'function') {
+    console.clear();
+  }
+}
+
+function setup() {
+  var client = new HmrClient(
+    // TODO: make the URL/Entrypoint configurable
+    `ws://localhost:8082/hot?bundleEntry=src/index.js`,
+  );
+  client.enable();
+
+  client.on('update', function() {
+    if (lastError) {
+      clearOutdatedErrors();
+      ErrorOverlay.dismissBuildError();
+    }
+    lastError = null;
+  });
+  client.on('error', function(error) {
+    lastError = error;
+    clearOutdatedErrors();
+    ErrorOverlay.reportBuildError(error.message);
+
+    if (typeof console !== 'undefined' && typeof console.error === 'function') {
+      console.error(error.message);
+    }
+  });
+}
+
+try {
+  // If this module itself is hot-reloaded, this call will throw.
+  ErrorOverlay.startReportingRuntimeErrors({
+    onError: function() {},
+    filename: '/js-bundle.js',
+  });
+} catch (e) {}
+
+if (!setupDone) {
+  setup();
+  setupDone = true;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,6 +1955,10 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-error-overlay@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
+
 react-proxy@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-1.1.8.tgz#9dbfd9d927528c3aa9f444e4558c37830ab8c26a"


### PR DESCRIPTION
This is a basic version of an error overlay for Metro's HMR server. It's based on create-react-app's [`react-error-overlay`](https://github.com/facebook/create-react-app/tree/next/packages/react-error-overlay). I know that weeks of work went into making that overlay solid. It's implementation is sound (an iframe with the highest z-index served by a single file bundle that includes React) and battle tested inside of create-react-app.

The behavior is incomplete but should kick this effort off the ground:
* When changing a file and introducing a syntax error, it will show an error overlay, clear the console and print the error there as well.
* When changing a file and the syntax error remains, it will clear the console and update the error message.
* When fixing the error, the overlay will go away and the console will be clear.
* When changing a file without syntax errors, everything keeps working.
* When changing a file with a syntax error and reloading, nothing works yet (see below).

In the sample app, this is incredibly fast:
![errors](https://user-images.githubusercontent.com/13352/35627041-95ecdc08-068f-11e8-8d3b-2882f72d8bb0.gif)


Next steps:
* Bring this to FB; it's probably best to make a compose-able metro-web package with a basic set of features that we need (I'm working on this now).
* Turn the HmrServer and HmrClient into a general MetroServer and MetroClient so that we can communicate hmr updates, errors as well as delta updates (cc @davidaurelio) over web sockets.
* Make this also work for initial loads when a user bundle doesn't compile on the initial load. From my perspective the best option would be to:
 * Load the metro-web client as a separate bundle from Metro, this should never fail compilation
 * Every user bundle that is generated should generate a piece of code like `MetroClient.listen('path/to/bundle')`. This is convenient because we can make sure to listen to many bundles at the same time as well as we don't need to make the URL/entry points configurable from within user code.
* Include the code frame in the error message so that it's actually useful.
* Polish (open in editor, …).

@rafeca what do you think about these next steps?